### PR TITLE
[DEPLOY-1] Configure Vercel deployment URLs for frontend and backend

### DIFF
--- a/pkgs/app/.env.example
+++ b/pkgs/app/.env.example
@@ -1,0 +1,3 @@
+# API base URL (optional)
+# Defaults to http://localhost:3000 in dev, https://cultivate-be.vercel.app in production
+# VITE_API_URL=https://cultivate-be.vercel.app

--- a/pkgs/app/src/providers/apiProvider.tsx
+++ b/pkgs/app/src/providers/apiProvider.tsx
@@ -7,9 +7,12 @@ export function ApiProvider({ children }: PropsWithChildren) {
   // 1. attempt to make request i.e. /auth/login
   // 2. request successful, return i.e. /auth/login triggers side-effect to store token
   // 3. request fails with 401, goto login with redirect_url set
+  const basePath =
+    import.meta.env.VITE_API_URL ||
+    (import.meta.env.DEV ? 'http://localhost:3000' : 'https://cultivate-be.vercel.app')
   const config = new Configuration({
     accessToken: undefined,
-    basePath: 'http://localhost:3000',
+    basePath,
   })
   const misc = new DefaultApi(config)
   const listings = new ListingsApi(config)

--- a/pkgs/server/src/index.ts
+++ b/pkgs/server/src/index.ts
@@ -72,8 +72,10 @@ app.get(
       },
       servers: [
         {
-          // TODO: get host URL from env var.
-          url: 'http://localhost:3000',
+          url:
+            process.env.VERCEL_URL
+              ? `https://${process.env.VERCEL_URL}`
+              : process.env.API_URL || 'http://localhost:3000',
         },
       ],
     },


### PR DESCRIPTION
- Frontend (pkgs/app): apiProvider now uses https://cultivate-be.vercel.app in production and http://localhost:3000 in dev, with optional override via VITE_API_URL.
- Backend (pkgs/server): OpenAPI servers URL is set dynamically from VERCEL_URL when deployed, or API_URL otherwise.
- Docs: Added pkgs/app/.env.example

**Deployment URLs**
Frontend: https://cultivate-fe.vercel.app/
Backend: https://cultivate-be.vercel.app/