### PR TITLE
Add Vercel configuration for URL rewrites

### DIFF
--- a/pkgs/app/vercel.json
+++ b/pkgs/app/vercel.json
@@ -1,0 +1,9 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}
+


### PR DESCRIPTION
Fix client-side routing 404s on Vercel for deep links

Issue: Refreshing or directly visiting routes like /listings in production returned a 404 from Vercel (GET https://cultivate-fe.vercel.app/listings 404 (Not Found)), because Vercel attempted to serve /listings as a static file instead of handing it to the React Router SPA.

Root cause: The app uses BrowserRouter with clean URLs, but there was no SPA fallback configured in the Vercel project, so unknown paths did not rewrite to index.html.

**Fix**
- Added pkgs/app/vercel.json with a catch‑all rewrite rule: source: "/(.*)" → destination: "/"
- Ensures all non-static requests are served index.html, letting React Router handle client-side navigation (including /listings and other deep links) without 404s in production.